### PR TITLE
Update Column.cs to support RowGuidCol

### DIFF
--- a/model/Models/Column.cs
+++ b/model/Models/Column.cs
@@ -57,7 +57,7 @@ namespace SchemaZen.Library.Models {
 			}
 		}
 
-		public string RowGuidColText => IsRowGuidCol ? "ROWGUIDCOL" : string.Empty;
+		public string RowGuidColText => IsRowGuidCol ? " ROWGUIDCOL " : string.Empty;
 
 		public ColumnDiff Compare(Column c) {
 			return new ColumnDiff(this, c);
@@ -98,7 +98,7 @@ namespace SchemaZen.Library.Models {
 					val.Append($" {IsNullableText}");
 					if (includeDefaultConstraint) val.Append(DefaultText);
 					if (Identity != null) val.Append(IdentityText);
-					if (IsRowGuidCol) val.Append(@" {RowGuidColText}");
+					if (IsRowGuidCol) val.Append(RowGuidColText);
 					return val.ToString();
 
 				case "binary":


### PR DESCRIPTION
Ran into an edge case and noticed my definition would fail to create.

With the following example:

CREATE DATABASE [rowguidcol]
go
CREATE TABLE [dbo].[Failure] (
   [NodeGUID] [uniqueidentifier] NOT NULL default (newsequentialid()) ROWGUIDCOL,
)

Produced a create statement with ROWGUIDCOL replaced with {RowGuidColText}, I did not do extensive testing on this fix, but this looks right. 

Adding another commit with regards to escaping databases with keywords in them next :) 
